### PR TITLE
Add vertical margin for closed order form

### DIFF
--- a/src/components/OrderFormDialog.tsx
+++ b/src/components/OrderFormDialog.tsx
@@ -41,6 +41,7 @@ const StyledDialogHeader = styled.header`
   border-radius: 5px 5px 0 0;
   display: flex;
   flex-direction: column;
+  margin-bottom: 12px;
 `;
 
 const StyledCloseButton = styled.button`


### PR DESCRIPTION
When a Google forms instance is in "closed" state, the top margin is missing, causing there to be no space between the form and the dialog header.