### PR TITLE
Move Instagram feed reinitialization into useEffect hook

### DIFF
--- a/src/components/InstagramFeed.tsx
+++ b/src/components/InstagramFeed.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import useScript from '../hooks/use-script';
 
@@ -16,18 +16,20 @@ const InstagramFeed: React.FC = () => {
   useScript('https://w.behold.so/widget.js', 'module');
   const beholdFigureRef = useRef<HTMLElement>(null);
 
-  /**
-   * Reinitialize Behold widgets if the Behold figure element has no children.
-   * This happens when users change route to a page containing this component
-   * after the Behold widgets have already been initialized in the current
-   * session.
-   */
-  if (
-    beholdFigureRef.current?.childElementCount === 0 &&
-    typeof window.beholdWidgets?.initialize === 'function'
-  ) {
-    window.beholdWidgets.initialize();
-  }
+  useEffect(() => {
+    /**
+     * Reinitialize Behold widgets if the Behold figure element has no
+     * children. This happens when users change route to a page containing this
+     * component after the Behold widgets have already been initialized in the
+     * current session.
+     */
+    if (
+      beholdFigureRef.current?.childElementCount === 0 &&
+      typeof window.beholdWidgets?.initialize === 'function'
+    ) {
+      window.beholdWidgets.initialize();
+    }
+  }, []);
 
   return (
     <StyledInstagramFeed>


### PR DESCRIPTION
The reinitialization was not being invoked on route change due to the figure element not being rendered at the time of execution. Moving the logic into a `useEffect` with empty dependencies array ensures the code will run once after render.