### PR TITLE
Add css variables for dark mode appearance

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,6 @@ import {
   FOOTER_TOP_MARGIN_PX,
   WINDOW_NARROW_WIDTH_PX,
 } from '../constants/breakpoint';
-import { SOFT_WHITE, THEME_NAVY } from '../constants/color';
 import { increaseKernelCount } from '../utilities/click-pop';
 
 const StyledFooter = styled.footer`
@@ -17,7 +16,7 @@ const StyledFooter = styled.footer`
 
 const StyledThemeSection = styled.div`
   align-items: center;
-  background-color: var(--main-theme-dark);
+  background-color: var(--color-theme-background);
   display: flex;
   height: 400px;
   justify-content: center;
@@ -27,10 +26,6 @@ const StyledThemeSection = styled.div`
 
   @media (max-width: ${WINDOW_NARROW_WIDTH_PX}px) {
     height: 280px;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${THEME_NAVY};
   }
 `;
 
@@ -58,11 +53,7 @@ const StyledSocialLinksContainer = styled.div`
 const StyledPopcornButton = styled.button`
   background-color: transparent;
   border: none;
-  color: ${THEME_NAVY};
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-  }
+  color: var(--color-foreground);
 `;
 
 const StyledCopyright = styled(Typography)`

--- a/src/components/MobileNavigationBar.tsx
+++ b/src/components/MobileNavigationBar.tsx
@@ -5,7 +5,6 @@ import {
   MOBILE_NAVIGATION_BAR_HEIGHT_PX,
   WINDOW_BREAKPOINT_WIDTH_PX,
 } from '../constants/breakpoint';
-import { SOFT_BLACK, SOFT_WHITE, THEME_NAVY, WHITE } from '../constants/color';
 import WordmarkSvg from '../images/jerrypop-wordmark-navy.svg';
 import WordmarkSvgDark from '../images/jerrypop-wordmark-soft-white.svg';
 import { NavigationMenuItem } from '../types/navigation';
@@ -43,6 +42,7 @@ const StyledNavigationBar = styled.nav`
 const StyledNavigationBarContent = styled.div<Slideable>`
   ${SLIDE_STYLE}
   ${NAVIGATION_BAR_STYLE}
+  background-color: var(--color-background);
   left: 0;
   padding: 0;
   position: absolute;
@@ -71,13 +71,9 @@ const StyledHamburgerButton = styled.button`
 `;
 
 const StyledHamburgerLine = styled.div`
-  background-color: ${THEME_NAVY};
+  background-color: var(--color-foreground);
   height: 2px;
   width: 100%;
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_WHITE};
-  }
 `;
 
 const StyledWordmarkLink = styled(Link)`
@@ -100,17 +96,13 @@ const StyledCloseButton = styled.button`
 
 const StyledCloseButtonIcon = styled.div`
   align-items: center;
-  color: ${THEME_NAVY};
+  color: var(--color-foreground);
   display: flex;
   font-size: 24px;
   font-weight: 500;
   // Add 2px just to be safe. Chrome on iPhone shows a tiny sliver of a gap.
   height: ${MENU_ITEM_HEIGHT_PX + 2}px;
   padding: 0 24px;
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-  }
 `;
 
 const StyledMenuItems = styled.ul<Slideable>`
@@ -119,17 +111,13 @@ const StyledMenuItems = styled.ul<Slideable>`
   @media (max-width: ${WINDOW_BREAKPOINT_WIDTH_PX}px) {
     ${SLIDE_STYLE}
     ${NAVIGATION_MENU_LIST_STYLE}
-    background-color: ${WHITE};
+    background-color: var(--color-background);
     display: block;
     left: 0;
     position: absolute;
     right: 0;
     top: -${({ slideDistancePx }) => slideDistancePx}px;
     z-index: ${NAVIGATION_MENU_Z_INDEX};
-
-    @media (prefers-color-scheme: dark) {
-      background-color: ${SOFT_BLACK};
-    }
   }
 `;
 

--- a/src/components/OrderFormDialog.tsx
+++ b/src/components/OrderFormDialog.tsx
@@ -1,11 +1,4 @@
-import {
-  DIALOG_BACKDROP,
-  ICON_HOVER_BACKGROUND,
-  ICON_HOVER_LIGHT_BACKGROUND,
-  SOFT_BLACK,
-  SOFT_WHITE,
-  WHITE,
-} from '../constants/color';
+import { DIALOG_BACKDROP } from '../constants/color';
 import { DIALOG_BACKDROP_Z_INDEX, DIALOG_Z_INDEX } from '../constants/z-index';
 import React from 'react';
 import styled from 'styled-components';
@@ -25,7 +18,7 @@ interface StyledDialogProps {
 
 const StyledDialog = styled.dialog<StyledDialogProps>`
   ${WITH_BOX_SHADOW_STYLE}
-  background-color: ${WHITE};
+  background-color: var(--color-background);
   border: none;
   border-radius: 5px;
   display: flex;
@@ -36,23 +29,14 @@ const StyledDialog = styled.dialog<StyledDialogProps>`
   top: ${VERTICAL_MARGIN_PX}px;
   width: ${({ dialogWidth }) => dialogWidth}px;
   z-index: ${DIALOG_Z_INDEX};
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_BLACK};
-  }
 `;
 
 const StyledDialogHeader = styled.header`
   align-items: flex-end;
-  background-color: var(--main-theme-dark);
   border-radius: 5px 5px 0 0;
   display: flex;
   flex-direction: column;
   margin-bottom: ${FORM_TOP_MARGIN_PX}px;
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_BLACK};
-  }
 `;
 
 const StyledCloseButton = styled.button`
@@ -60,7 +44,7 @@ const StyledCloseButton = styled.button`
   background-color: transparent;
   border: none;
   border-radius: 50%;
-  color: var(--theme-text-on-dark);
+  color: var(--color-foreground);
   cursor: pointer;
   display: flex;
   font-family: sans-serif;
@@ -74,16 +58,7 @@ const StyledCloseButton = styled.button`
 
   &:hover,
   &:focus {
-    background-color: ${ICON_HOVER_BACKGROUND};
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-
-    &:hover,
-    &:focus {
-      background-color: ${ICON_HOVER_LIGHT_BACKGROUND};
-    }
+    background-color: var(--icon-hover-background);
   }
 `;
 

--- a/src/components/RequestCateringDialog.tsx
+++ b/src/components/RequestCateringDialog.tsx
@@ -1,11 +1,4 @@
-import {
-  DIALOG_BACKDROP,
-  ICON_HOVER_BACKGROUND,
-  ICON_HOVER_LIGHT_BACKGROUND,
-  SOFT_BLACK,
-  SOFT_WHITE,
-  WHITE,
-} from '../constants/color';
+import { DIALOG_BACKDROP } from '../constants/color';
 import { DIALOG_BACKDROP_Z_INDEX, DIALOG_Z_INDEX } from '../constants/z-index';
 import React from 'react';
 import styled from 'styled-components';
@@ -25,7 +18,7 @@ interface StyledDialogProps {
 
 const StyledDialog = styled.dialog<StyledDialogProps>`
   ${WITH_BOX_SHADOW_STYLE}
-  background-color: ${WHITE};
+  background-color: var(--color-background);
   border: none;
   border-radius: 5px;
   display: flex;
@@ -36,23 +29,14 @@ const StyledDialog = styled.dialog<StyledDialogProps>`
   top: ${VERTICAL_MARGIN_PX}px;
   width: ${({ dialogWidth }) => dialogWidth}px;
   z-index: ${DIALOG_Z_INDEX};
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_BLACK};
-  }
 `;
 
 const StyledDialogHeader = styled.header`
   align-items: flex-end;
-  background-color: var(--main-theme-dark);
   border-radius: 5px 5px 0 0;
   display: flex;
   flex-direction: column;
   margin-bottom: ${FORM_TOP_MARGIN_PX}px;
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_BLACK};
-  }
 `;
 
 const StyledCloseButton = styled.button`
@@ -60,7 +44,7 @@ const StyledCloseButton = styled.button`
   background-color: transparent;
   border: none;
   border-radius: 50%;
-  color: var(--theme-text-on-dark);
+  color: var(--color-foreground);
   cursor: pointer;
   display: flex;
   font-family: sans-serif;
@@ -74,16 +58,7 @@ const StyledCloseButton = styled.button`
 
   &:hover,
   &:focus {
-    background-color: ${ICON_HOVER_BACKGROUND};
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-
-    &:hover,
-    &:focus {
-      background-color: ${ICON_HOVER_LIGHT_BACKGROUND};
-    }
+    background-color: var(--icon-hover-background);
   }
 `;
 

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -7,7 +7,6 @@ export const WHITE = '#fff';
 /**
  * Dark mode colors
  */
-export const GRAYSCALE_FILTER = 'grayscale(15%)';
 export const SOFT_BLACK = 'rgb(32, 32, 32)';
 export const SOFT_WHITE = 'rgb(250, 250, 250)';
 export const ICON_HOVER_LIGHT_BACKGROUND = 'rgba(250, 250, 250, 0.1)';

--- a/src/constants/css/button.ts
+++ b/src/constants/css/button.ts
@@ -1,13 +1,12 @@
-import { SOFT_WHITE, THEME_NAVY, WHITE } from '../color';
 import { css } from 'styled-components';
 import { DANGLE_STYLE } from './rotation';
 
 export const BUTTON_STYLE = css`
   align-items: center;
-  background-color: ${THEME_NAVY};
+  background-color: var(--color-foreground);
   border: none;
   border-radius: 3px;
-  color: ${WHITE};
+  color: var(--color-background);
   cursor: pointer;
   display: flex;
   font-size: 14px;
@@ -21,16 +20,6 @@ export const BUTTON_STYLE = css`
   &:hover,
   &:focus {
     ${DANGLE_STYLE}
-    color: ${WHITE};
-  }
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_WHITE};
-    color: ${THEME_NAVY};
-
-    &:hover,
-    &:focus {
-      color: ${THEME_NAVY};
-    }
+    color: var(--color-background);
   }
 `;

--- a/src/constants/css/card.ts
+++ b/src/constants/css/card.ts
@@ -1,5 +1,4 @@
 import { css } from 'styled-components';
-import { SOFT_WHITE, THEME_NAVY } from '../color';
 
 export const CARD_OUTER_STYLE = css`
   border-radius: 5px;
@@ -15,13 +14,8 @@ export const CARD_OUTER_STYLE = css`
 
 export const CARD_INNER_STYLE = css`
   border-radius: 5px;
-  color: ${THEME_NAVY};
   padding: 24px 16px;
   text-align: left;
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-  }
 `;
 
 export const CARD_TITLE_STYLE = css`

--- a/src/constants/css/global-style.ts
+++ b/src/constants/css/global-style.ts
@@ -1,5 +1,6 @@
 import {
-  GRAYSCALE_FILTER,
+  ICON_HOVER_BACKGROUND,
+  ICON_HOVER_LIGHT_BACKGROUND,
   SOFT_BLACK,
   SOFT_WHITE,
   THEME_NAVY,
@@ -24,8 +25,22 @@ export const GLOBAL_STYLE = createGlobalStyle`
 }
 
 body {
-  background-color: ${WHITE};
-  color: ${THEME_NAVY};
+  --color-background: ${WHITE};
+  --color-foreground: ${THEME_NAVY};
+  --color-theme-background: var(--main-theme-dark);
+  --icon-hover-background: ${ICON_HOVER_BACKGROUND};
+  --image-filter: none;
+
+  @media (prefers-color-scheme: dark) {
+    --color-background: ${SOFT_BLACK};
+    --color-foreground: ${SOFT_WHITE};
+    --color-theme-background: ${THEME_NAVY};
+    --icon-hover-background: ${ICON_HOVER_LIGHT_BACKGROUND};
+    --image-filter: grayscale(0.15);
+  }
+
+  background-color: var(--color-background);
+  color: var(--color-foreground);
   font-family: 'Open Sans', 'Helvetica Neue', sans-serif;
   margin: 0;
   padding: ${DESKTOP_NAVIGATION_BAR_HEIGHT_PX}px 0 0;
@@ -36,11 +51,6 @@ body {
   @media (max-width: ${WINDOW_BREAKPOINT_WIDTH_PX}px) {
     padding: ${MOBILE_NAVIGATION_BAR_HEIGHT_PX}px 0 0;
   }
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_BLACK};
-    color: ${SOFT_WHITE};
-  }
 }
 
 :focus {
@@ -48,28 +58,18 @@ body {
 }
 
 img:not([src*='.svg']) {
-  @media (prefers-color-scheme: dark) {
-    filter: ${GRAYSCALE_FILTER};
-  }
+  filter: var(--image-filter);
 }
 
 a {
-  color: ${THEME_NAVY};
+  color: var(--color-foreground);
   cursor: pointer;
   text-decoration: underline;
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-  }
 }
 
 a:focus,
 a:hover {
-  color: ${THEME_NAVY};
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-  }
+  color: var(--color-foreground);
 }
 
 button {

--- a/src/constants/css/navigation-bar.ts
+++ b/src/constants/css/navigation-bar.ts
@@ -1,16 +1,9 @@
 import { css } from 'styled-components';
-import { SOFT_BLACK, SOFT_WHITE, THEME_NAVY, WHITE } from '../color';
 import { NAVIGATION_BAR_Z_INDEX } from '../z-index';
 
 export const NAVIGATION_BAR_STYLE = css`
-  background-color: ${WHITE};
   display: flex;
   z-index: ${NAVIGATION_BAR_Z_INDEX};
-
-  @media (prefers-color-scheme: dark) {
-    background-color: ${SOFT_BLACK};
-    color: ${SOFT_WHITE};
-  }
 `;
 
 export const NAVIGATION_BAR_CONTENT_STYLE = css`
@@ -27,26 +20,11 @@ export const NAVIGATION_MENU_LIST_STYLE = css`
 `;
 
 export const NAVIGATION_MENU_LINK_STYLE = css`
-  color: ${THEME_NAVY};
   cursor: pointer;
   display: block;
   letter-spacing: 0.25px;
   text-decoration: none;
   text-transform: uppercase;
-
-  &:hover,
-  &:focus {
-    color: ${THEME_NAVY};
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: ${SOFT_WHITE};
-
-    &:hover,
-    &:focus {
-      color: ${SOFT_WHITE};
-    }
-  }
 `;
 
 export const NAVIGATION_BAR_WORDMARK_LINK_STYLE = css`


### PR DESCRIPTION
This consolidates all dark-mode media queries into a single global media query, allowing the rest of the application to simply reference the variable values.