### PR TITLE
Reduce size of packaging images

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -12,7 +12,7 @@ import HabaneroRanchWebp2400 from '../images/glamorous-habanero-ranch-2400.webp'
 import {
   FOOTER_TOP_MARGIN_PX,
   TILE_LIST_BREAKPOINT_WIDTH_PX,
-  TILE_LIST_IMAGE_WIDTH_PX,
+  DEFAULT_TILE_LIST_IMAGE_WIDTH_PX,
   WINDOW_BREAKPOINT_WIDTH_PX,
 } from '../constants/breakpoint';
 import { Link } from 'react-router-dom';
@@ -62,7 +62,7 @@ const StyledDivider = styled.div`
   width: ${TILE_LIST_BREAKPOINT_WIDTH_PX - 2 * TILE_HORIZONTAL_MARGIN_PX}px;
 
   @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
-    max-width: ${TILE_LIST_IMAGE_WIDTH_PX}px;
+    max-width: ${DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
     width: calc(100% - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
   }
 `;

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -9,8 +9,8 @@ import HabaneroRanch2400 from '../images/glamorous-habanero-ranch-2400.jpeg';
 import HabaneroRanchWebp600 from '../images/glamorous-habanero-ranch-600.webp';
 import HabaneroRanchWebp1200 from '../images/glamorous-habanero-ranch-1200.webp';
 import HabaneroRanchWebp2400 from '../images/glamorous-habanero-ranch-2400.webp';
+import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/css/tile-list';
 import {
-  DEFAULT_TILE_LIST_IMAGE_WIDTH_PX,
   FOOTER_TOP_MARGIN_PX,
   WINDOW_BREAKPOINT_WIDTH_PX,
 } from '../constants/breakpoint';

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -10,18 +10,14 @@ import HabaneroRanchWebp600 from '../images/glamorous-habanero-ranch-600.webp';
 import HabaneroRanchWebp1200 from '../images/glamorous-habanero-ranch-1200.webp';
 import HabaneroRanchWebp2400 from '../images/glamorous-habanero-ranch-2400.webp';
 import {
-  FOOTER_TOP_MARGIN_PX,
-  TILE_LIST_BREAKPOINT_WIDTH_PX,
   DEFAULT_TILE_LIST_IMAGE_WIDTH_PX,
+  FOOTER_TOP_MARGIN_PX,
   WINDOW_BREAKPOINT_WIDTH_PX,
 } from '../constants/breakpoint';
 import { Link } from 'react-router-dom';
 import { BUTTON_STYLE } from '../constants/css/button';
 import PressArticles from './PressArticles';
-import {
-  TILE_HORIZONTAL_MARGIN_PX,
-  TILE_VERTICAL_MARGIN_PX,
-} from '../constants/css/tile-list';
+import { TILE_LIST_DIVIDER_STYLE } from '../constants/css/tile-list';
 
 const StyledHome = styled.div`
   align-items: center;
@@ -56,15 +52,7 @@ const StyledCallToActionLink = styled(Link)`
 `;
 
 const StyledDivider = styled.div`
-  background-color: var(--color-foreground);
-  height: 1px;
-  margin-bottom: ${TILE_VERTICAL_MARGIN_PX}px;
-  width: ${TILE_LIST_BREAKPOINT_WIDTH_PX - 2 * TILE_HORIZONTAL_MARGIN_PX}px;
-
-  @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
-    max-width: ${DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
-    width: calc(100% - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
-  }
+  ${TILE_LIST_DIVIDER_STYLE}
 `;
 
 const Home: React.FC = () => {
@@ -87,7 +75,10 @@ const Home: React.FC = () => {
           </StyledTagline>
           <StyledCallToActionLink to="/order">Order</StyledCallToActionLink>
         </StyledRegularSection>
-        <StyledDivider aria-hidden={true} />
+        <StyledDivider
+          aria-hidden={true}
+          $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
+        />
         <PressArticles />
       </StyledHome>
     </>

--- a/src/components/PressArticles.tsx
+++ b/src/components/PressArticles.tsx
@@ -10,7 +10,7 @@ import {
   TILE_LIST_ITEM_LINK_STYLE,
 } from '../constants/css/tile-list';
 import { ARTICLES } from '../constants/press';
-import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
+import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/css/tile-list';
 import OptimizedImage from './OptimizedImage';
 
 const StyledTileList = styled.ul`

--- a/src/components/PressArticles.tsx
+++ b/src/components/PressArticles.tsx
@@ -7,12 +7,10 @@ import {
   TILE_IMAGE_CONTAINER_STYLE,
   TILE_IMAGE_STYLE,
   TILE_INFORMATION_STYLE,
+  TILE_LIST_ITEM_LINK_STYLE,
 } from '../constants/css/tile-list';
 import { ARTICLES } from '../constants/press';
-import {
-  TILE_LIST_BREAKPOINT_WIDTH_PX,
-  DEFAULT_TILE_LIST_IMAGE_WIDTH_PX,
-} from '../constants/breakpoint';
+import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
 import OptimizedImage from './OptimizedImage';
 
 const StyledTileList = styled.ul`
@@ -24,19 +22,7 @@ const StyledTileListItem = styled.li`
 `;
 
 const StyledArticleListItem = styled.a`
-  align-items: center;
-  display: flex;
-  // Margin and padding provide rectangular focus state outline.
-  margin: -8px;
-  padding: 8px;
-  text-decoration: none;
-
-  @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
-    flex-direction: column;
-    margin-left: 0;
-    margin-right: 0;
-    width: 100%;
-  }
+  ${TILE_LIST_ITEM_LINK_STYLE}
 `;
 
 const StyledTileImageContainer = styled.div`
@@ -66,15 +52,23 @@ const PressArticles: React.FC = () => {
   return (
     <StyledTileList>
       {ARTICLES.map((article) => (
-        <StyledTileListItem key={article.title}>
+        <StyledTileListItem
+          $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
+          key={article.title}
+        >
           <StyledArticleListItem
+            $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
             href={article.href}
             rel="noreferrer"
             target="_blank"
           >
-            <StyledTileImageContainer $aspectRatio={1}>
+            <StyledTileImageContainer
+              $aspectRatio={1}
+              $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
+            >
               <StyledTileImage
                 $aspectRatio={1}
+                $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
                 alt={article.imageAltText}
                 fallbackSrc={article.image}
                 fallbackSrcSet={`${article.image} 600w`}
@@ -82,7 +76,9 @@ const PressArticles: React.FC = () => {
                 srcSet={`${article.imageWebp} 600w`}
               />
             </StyledTileImageContainer>
-            <StyledTileInformation>
+            <StyledTileInformation
+              $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
+            >
               <StyledArticlePublication type="p">
                 {article.publication}
               </StyledArticlePublication>

--- a/src/components/PressArticles.tsx
+++ b/src/components/PressArticles.tsx
@@ -11,7 +11,7 @@ import {
 import { ARTICLES } from '../constants/press';
 import {
   TILE_LIST_BREAKPOINT_WIDTH_PX,
-  TILE_LIST_IMAGE_WIDTH_PX,
+  DEFAULT_TILE_LIST_IMAGE_WIDTH_PX,
 } from '../constants/breakpoint';
 import OptimizedImage from './OptimizedImage';
 
@@ -78,7 +78,7 @@ const PressArticles: React.FC = () => {
                 alt={article.imageAltText}
                 fallbackSrc={article.image}
                 fallbackSrcSet={`${article.image} 600w`}
-                sizes={`${TILE_LIST_IMAGE_WIDTH_PX}px (min-width: ${TILE_LIST_IMAGE_WIDTH_PX}px), 95vw`}
+                sizes={`${DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px (min-width: ${DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px), 95vw`}
                 srcSet={`${article.imageWebp} 600w`}
               />
             </StyledTileImageContainer>

--- a/src/components/PricingListItem.tsx
+++ b/src/components/PricingListItem.tsx
@@ -8,7 +8,7 @@ import {
   TILE_IMAGE_STYLE,
   TILE_INFORMATION_STYLE,
 } from '../constants/css/tile-list';
-import { TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
+import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
 import OptimizedImage from './OptimizedImage';
 import { displayCurrency } from '../utilities/currency';
 

--- a/src/components/PricingListItem.tsx
+++ b/src/components/PricingListItem.tsx
@@ -8,11 +8,11 @@ import {
   TILE_IMAGE_STYLE,
   TILE_INFORMATION_STYLE,
 } from '../constants/css/tile-list';
-import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
 import OptimizedImage from './OptimizedImage';
 import { displayCurrency } from '../utilities/currency';
 
 const PACKAGING_IMAGE_ASPECT_RATIO = 1.285;
+const PACKAGING_IMAGE_WIDTH_PX = 240;
 
 const StyledTileListItem = styled.li`
   ${TILE_LIST_ITEM_STYLE}
@@ -75,18 +75,22 @@ type Props = CateringProps | RetailProps;
 
 const PricingListItem: React.FC<Props> = ({ product, type }) => {
   return (
-    <StyledTileListItem>
-      <StyledTileImageContainer $aspectRatio={PACKAGING_IMAGE_ASPECT_RATIO}>
+    <StyledTileListItem $imageWidthPx={PACKAGING_IMAGE_WIDTH_PX}>
+      <StyledTileImageContainer
+        $aspectRatio={PACKAGING_IMAGE_ASPECT_RATIO}
+        $imageWidthPx={PACKAGING_IMAGE_WIDTH_PX}
+      >
         <StyledTileImage
           $aspectRatio={PACKAGING_IMAGE_ASPECT_RATIO}
+          $imageWidthPx={PACKAGING_IMAGE_WIDTH_PX}
           alt={`Front packaging label for ${product.title}`}
           fallbackSrc={product.packagingImage}
           fallbackSrcSet={`${product.packagingImage} 600w`}
-          sizes={`${TILE_LIST_IMAGE_WIDTH_PX}px (min-width: ${TILE_LIST_IMAGE_WIDTH_PX}px), 95vw`}
+          sizes={`${PACKAGING_IMAGE_WIDTH_PX}px (min-width: ${PACKAGING_IMAGE_WIDTH_PX}px), 95vw`}
           srcSet={`${product.packagingImageWebp} 600w`}
         />
       </StyledTileImageContainer>
-      <StyledTileInformation>
+      <StyledTileInformation $imageWidthPx={PACKAGING_IMAGE_WIDTH_PX}>
         <StyledTitle type="h3">{product.title}</StyledTitle>
         <StyledSubtitle type="p">{`${product.weight} ${product.subtitle}`}</StyledSubtitle>
         <Typography margin="16px 0 0" type="p">

--- a/src/components/ProductListing.tsx
+++ b/src/components/ProductListing.tsx
@@ -52,10 +52,14 @@ interface Props {
 
 const ProductListing: React.FC<Props> = ({ product }) => {
   return (
-    <StyledTileListItem>
-      <StyledTileImageContainer $aspectRatio={1}>
+    <StyledTileListItem $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}>
+      <StyledTileImageContainer
+        $aspectRatio={1}
+        $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
+      >
         <StyledTileImage
           $aspectRatio={1}
+          $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}
           alt={`Photograph of ${product.title}`}
           fallbackSrc={product.image}
           fallbackSrcSet={`${product.image} 600w`}
@@ -63,7 +67,7 @@ const ProductListing: React.FC<Props> = ({ product }) => {
           srcSet={`${product.imageWebp} 600w`}
         />
       </StyledTileImageContainer>
-      <StyledTileInformation>
+      <StyledTileInformation $imageWidthPx={DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}>
         <StyledTitle type="h2">{product.title}</StyledTitle>
         <StyledSubtitle type="p">{product.subtitle}</StyledSubtitle>
         <Typography margin="16px 0 0" type="p">

--- a/src/components/ProductListing.tsx
+++ b/src/components/ProductListing.tsx
@@ -8,7 +8,7 @@ import {
   TILE_IMAGE_STYLE,
   TILE_INFORMATION_STYLE,
 } from '../constants/css/tile-list';
-import { TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
+import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
 import OptimizedImage from './OptimizedImage';
 
 const StyledTileListItem = styled.li`
@@ -59,7 +59,7 @@ const ProductListing: React.FC<Props> = ({ product }) => {
           alt={`Photograph of ${product.title}`}
           fallbackSrc={product.image}
           fallbackSrcSet={`${product.image} 600w`}
-          sizes={`${TILE_LIST_IMAGE_WIDTH_PX}px (min-width: ${TILE_LIST_IMAGE_WIDTH_PX}px), 95vw`}
+          sizes={`${DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px (min-width: ${DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px), 95vw`}
           srcSet={`${product.imageWebp} 600w`}
         />
       </StyledTileImageContainer>

--- a/src/components/ProductListing.tsx
+++ b/src/components/ProductListing.tsx
@@ -8,7 +8,7 @@ import {
   TILE_IMAGE_STYLE,
   TILE_INFORMATION_STYLE,
 } from '../constants/css/tile-list';
-import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/breakpoint';
+import { DEFAULT_TILE_LIST_IMAGE_WIDTH_PX } from '../constants/css/tile-list';
 import OptimizedImage from './OptimizedImage';
 
 const StyledTileListItem = styled.li`

--- a/src/constants/breakpoint.ts
+++ b/src/constants/breakpoint.ts
@@ -8,6 +8,3 @@ export const KERNEL_WIDE_SIZE_PX = 56;
 export const KERNEL_NARROW_SIZE_PX = 42;
 
 export const FOOTER_TOP_MARGIN_PX = 56;
-
-export const TILE_LIST_BREAKPOINT_WIDTH_PX = 700;
-export const DEFAULT_TILE_LIST_IMAGE_WIDTH_PX = 300;

--- a/src/constants/breakpoint.ts
+++ b/src/constants/breakpoint.ts
@@ -10,4 +10,4 @@ export const KERNEL_NARROW_SIZE_PX = 42;
 export const FOOTER_TOP_MARGIN_PX = 56;
 
 export const TILE_LIST_BREAKPOINT_WIDTH_PX = 700;
-export const TILE_LIST_IMAGE_WIDTH_PX = 300;
+export const DEFAULT_TILE_LIST_IMAGE_WIDTH_PX = 300;

--- a/src/constants/css/tile-list.ts
+++ b/src/constants/css/tile-list.ts
@@ -1,11 +1,15 @@
 import { css } from 'styled-components';
-import {
-  TILE_LIST_BREAKPOINT_WIDTH_PX,
-  DEFAULT_TILE_LIST_IMAGE_WIDTH_PX,
-} from '../breakpoint';
 
 export const TILE_HORIZONTAL_MARGIN_PX = 24;
 export const TILE_VERTICAL_MARGIN_PX = 32;
+
+function getTileListBreakpointWidth({
+  $imageWidthPx,
+}: {
+  $imageWidthPx: number;
+}) {
+  return 2 * $imageWidthPx + 3 * TILE_HORIZONTAL_MARGIN_PX;
+}
 
 export const TILE_LIST_STYLE = css`
   display: flex;
@@ -16,66 +20,90 @@ export const TILE_LIST_STYLE = css`
   margin: 0;
 `;
 
-export const TILE_LIST_ITEM_STYLE = css`
+export const TILE_LIST_ITEM_STYLE = css<{ $imageWidthPx: number }>`
   align-items: center;
   display: flex;
   margin: ${TILE_VERTICAL_MARGIN_PX}px ${TILE_HORIZONTAL_MARGIN_PX}px;
-  width: ${TILE_LIST_BREAKPOINT_WIDTH_PX - 2 * TILE_HORIZONTAL_MARGIN_PX}px;
 
-  @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
+  @media (max-width: ${getTileListBreakpointWidth}px) {
     flex-direction: column;
     margin: ${TILE_VERTICAL_MARGIN_PX}px 0;
     width: calc(100% - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
   }
 `;
 
+export const TILE_LIST_ITEM_LINK_STYLE = css<{ $imageWidthPx: number }>`
+  align-items: center;
+  display: flex;
+  // Margin and padding provide rectangular focus state outline.
+  margin: -8px;
+  padding: 8px;
+  text-decoration: none;
+
+  @media (max-width: ${getTileListBreakpointWidth}px) {
+    flex-direction: column;
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
+  }
+`;
+
 export const TILE_IMAGE_CONTAINER_STYLE = css<{
   $aspectRatio: number;
-  $imageWidthPx?: number;
+  $imageWidthPx: number;
 }>`
   align-items: center;
   display: flex;
   // Mitigate screen flash for image loading state ending
   height: ${({ $aspectRatio, $imageWidthPx }) =>
-    $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
+    $aspectRatio * $imageWidthPx}px;
   justify-content: center;
 
-  @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
+  @media (max-width: ${getTileListBreakpointWidth}px) {
     height: unset;
     max-height: ${({ $aspectRatio, $imageWidthPx }) =>
-      $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
-    max-width: ${({ $imageWidthPx }) =>
-      $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
+      $aspectRatio * $imageWidthPx}px;
+    max-width: ${({ $imageWidthPx }) => $imageWidthPx}px;
     width: calc(100vw - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
   }
 `;
 
 export const TILE_IMAGE_STYLE = css<{
   $aspectRatio: number;
-  $imageWidthPx?: number;
+  $imageWidthPx: number;
 }>`
   height: ${({ $aspectRatio, $imageWidthPx }) =>
-    $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
-  width: ${({ $imageWidthPx }) =>
-    $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
+    $aspectRatio * $imageWidthPx}px;
+  width: ${({ $imageWidthPx }) => $imageWidthPx}px;
 
-  @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
+  @media (max-width: ${getTileListBreakpointWidth}px) {
     height: unset;
     max-height: ${({ $aspectRatio, $imageWidthPx }) =>
-      $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
-    max-width: ${({ $imageWidthPx }) =>
-      $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
+      $aspectRatio * $imageWidthPx}px;
+    max-width: ${({ $imageWidthPx }) => $imageWidthPx}px;
     width: calc(100vw - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
   }
 `;
 
-export const TILE_INFORMATION_STYLE = css<{ $imageWidthPx?: number }>`
+export const TILE_INFORMATION_STYLE = css<{ $imageWidthPx: number }>`
   margin: 0 0 0 ${TILE_HORIZONTAL_MARGIN_PX}px;
+  max-width: ${({ $imageWidthPx }) => $imageWidthPx}px;
   text-align: left;
 
-  @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
+  @media (max-width: ${getTileListBreakpointWidth}px) {
     margin: 24px auto 0;
-    max-width: ${({ $imageWidthPx }) =>
-      $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
+  }
+`;
+
+export const TILE_LIST_DIVIDER_STYLE = css<{ $imageWidthPx: number }>`
+  background-color: var(--color-foreground);
+  height: 1px;
+  margin-bottom: ${TILE_VERTICAL_MARGIN_PX}px;
+  width: ${({ $imageWidthPx }) =>
+    2 * $imageWidthPx + TILE_HORIZONTAL_MARGIN_PX}px;
+
+  @media (max-width: ${getTileListBreakpointWidth}px) {
+    max-width: ${({ $imageWidthPx }) => $imageWidthPx}px;
+    width: calc(100% - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
   }
 `;

--- a/src/constants/css/tile-list.ts
+++ b/src/constants/css/tile-list.ts
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 
-export const TILE_HORIZONTAL_MARGIN_PX = 24;
-export const TILE_VERTICAL_MARGIN_PX = 32;
+const TILE_HORIZONTAL_MARGIN_PX = 24;
+const TILE_VERTICAL_MARGIN_PX = 32;
 
 function getTileListBreakpointWidth({
   $imageWidthPx,
@@ -10,6 +10,8 @@ function getTileListBreakpointWidth({
 }) {
   return 2 * $imageWidthPx + 3 * TILE_HORIZONTAL_MARGIN_PX;
 }
+
+export const DEFAULT_TILE_LIST_IMAGE_WIDTH_PX = 300;
 
 export const TILE_LIST_STYLE = css`
   display: flex;

--- a/src/constants/css/tile-list.ts
+++ b/src/constants/css/tile-list.ts
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import {
   TILE_LIST_BREAKPOINT_WIDTH_PX,
-  TILE_LIST_IMAGE_WIDTH_PX,
+  DEFAULT_TILE_LIST_IMAGE_WIDTH_PX,
 } from '../breakpoint';
 
 export const TILE_HORIZONTAL_MARGIN_PX = 24;
@@ -29,41 +29,53 @@ export const TILE_LIST_ITEM_STYLE = css`
   }
 `;
 
-export const TILE_IMAGE_CONTAINER_STYLE = css<{ $aspectRatio: number }>`
+export const TILE_IMAGE_CONTAINER_STYLE = css<{
+  $aspectRatio: number;
+  $imageWidthPx?: number;
+}>`
   align-items: center;
   display: flex;
   // Mitigate screen flash for image loading state ending
-  height: ${({ $aspectRatio }) => $aspectRatio * TILE_LIST_IMAGE_WIDTH_PX}px;
+  height: ${({ $aspectRatio, $imageWidthPx }) =>
+    $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
   justify-content: center;
 
   @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
     height: unset;
-    max-height: ${({ $aspectRatio }) =>
-      $aspectRatio * TILE_LIST_IMAGE_WIDTH_PX}px;
-    max-width: ${TILE_LIST_IMAGE_WIDTH_PX}px;
+    max-height: ${({ $aspectRatio, $imageWidthPx }) =>
+      $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
+    max-width: ${({ $imageWidthPx }) =>
+      $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
     width: calc(100vw - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
   }
 `;
 
-export const TILE_IMAGE_STYLE = css<{ $aspectRatio: number }>`
-  height: ${({ $aspectRatio }) => $aspectRatio * TILE_LIST_IMAGE_WIDTH_PX}px;
-  width: ${TILE_LIST_IMAGE_WIDTH_PX}px;
+export const TILE_IMAGE_STYLE = css<{
+  $aspectRatio: number;
+  $imageWidthPx?: number;
+}>`
+  height: ${({ $aspectRatio, $imageWidthPx }) =>
+    $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
+  width: ${({ $imageWidthPx }) =>
+    $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
 
   @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
     height: unset;
-    max-height: ${({ $aspectRatio }) =>
-      $aspectRatio * TILE_LIST_IMAGE_WIDTH_PX}px;
-    max-width: ${TILE_LIST_IMAGE_WIDTH_PX}px;
+    max-height: ${({ $aspectRatio, $imageWidthPx }) =>
+      $aspectRatio * ($imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX)}px;
+    max-width: ${({ $imageWidthPx }) =>
+      $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
     width: calc(100vw - ${2 * TILE_HORIZONTAL_MARGIN_PX}px);
   }
 `;
 
-export const TILE_INFORMATION_STYLE = css`
+export const TILE_INFORMATION_STYLE = css<{ $imageWidthPx?: number }>`
   margin: 0 0 0 ${TILE_HORIZONTAL_MARGIN_PX}px;
   text-align: left;
 
   @media (max-width: ${TILE_LIST_BREAKPOINT_WIDTH_PX}px) {
     margin: 24px auto 0;
-    max-width: ${TILE_LIST_IMAGE_WIDTH_PX}px;
+    max-width: ${({ $imageWidthPx }) =>
+      $imageWidthPx ?? DEFAULT_TILE_LIST_IMAGE_WIDTH_PX}px;
   }
 `;


### PR DESCRIPTION
- Add ability to customize tile image width
- Standardize tile information width
  - Assign tile information width equivalent to tile image width
  - Move all tile related css into appropriate constants module
  - Update pricing list item image width
- Move tile-specific constant to tile list constants module