### PR TITLE
Eagerly import close icon to prevent layout shift

### DIFF
--- a/src/components/MobileNavigationBar.tsx
+++ b/src/components/MobileNavigationBar.tsx
@@ -6,11 +6,7 @@ import WordmarkSvgDark from '../images/jerrypop-wordmark-soft-white.svg';
 import { NavigationMenuItem } from '../types/navigation';
 import Image from 'next/image';
 import HamburgerIcon from './icons/HamburgerIcon';
-import dynamic from 'next/dynamic';
-
-const CloseIcon = dynamic(() => import('./icons/CloseIcon'), {
-  ssr: false,
-});
+import CloseIcon from './icons/CloseIcon';
 
 interface Props {
   navigationMenuItems: NavigationMenuItem[];


### PR DESCRIPTION
The SVG icon is tiny, so there's no need to lazily load it, which is causing a layout shift on page load of the mobile navigation bar. This seems more reasonable than adding a fixed height container to enable lazily loading such a tiny icon.